### PR TITLE
feat: add show command to display managed hooks

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -1,0 +1,47 @@
+/*
+CONTRIBUTOR - @thatonecodes
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ezpieco/gethooky/internal/core"
+	"github.com/ezpieco/gethooky/utils"
+	"github.com/spf13/cobra"
+)
+
+var showCmd = &cobra.Command{
+	Use:   "show [hookname]",
+	Short: "Show all hooks or the contents of a specific hook",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		pwd, err := os.Getwd()
+		if err != nil {
+			fmt.Printf("❌ Failed to get current directory path:\n %v\n", err)
+			return
+		}
+
+		var hookName string
+		if len(args) == 1 {
+			hookName = args[0]
+		}
+
+		hookyDir := utils.GetHookyDir()
+		if _, err := os.Stat(hookyDir); os.IsNotExist(err) {
+			fmt.Println("❌ .hooky directory not found! Run `hooky init` first!")
+			return
+		}
+
+		if err := core.ShowHook(pwd, hookName); err != nil {
+			fmt.Printf("❌ %v\n", err)
+			return
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(showCmd)
+}

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -208,3 +208,53 @@ func UnignoreHook(basePath string, hookName string) error {
 
 	return nil
 }
+
+/*
+CONTRIBUTOR - @thatonecodes
+*/
+
+func ShowHook(basePath string, hookName string) error {
+	hookyDir := filepath.Join(basePath, utils.GetHookyDir())
+
+	if _, err := os.Stat(hookyDir); os.IsNotExist(err) {
+		return fmt.Errorf(".hooky directory not found. Please run `hooky init` first")
+	}
+
+	if hookName == "" {
+		files, err := os.ReadDir(hookyDir)
+		if err != nil {
+			return fmt.Errorf("failed to read .hooky directory: %v", err)
+		}
+
+		if len(files) == 0 {
+			fmt.Println("No hooks found.")
+			return nil
+		}
+
+		fmt.Println("Current hooks:")
+		for _, f := range files {
+			fmt.Printf("- %s\n", f.Name())
+		}
+		return nil
+	}
+
+	hookPath := filepath.Join(basePath, utils.GetHookyDir(), hookName)
+	fileInfo, err := os.Stat(hookPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("specified hook does not exist: %s", hookName)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to access hook: %v", err)
+	}
+	if fileInfo.IsDir() {
+		return fmt.Errorf("specified hook is a directory, not a file: %s", hookName)
+	}
+
+	content, err := os.ReadFile(hookPath)
+	if err != nil {
+		return fmt.Errorf("could not read hook %s: %v", hookName, err)
+	}
+	
+	fmt.Print(string(content))
+	return nil
+}

--- a/scoop/hooky.json
+++ b/scoop/hooky.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://github.com/EzpieCo/GetHooky/releases/download/v1.2.0/hooky.exe",
             "bin": "hooky.exe",
-            "hash": "sha256:a12bfdfbb5825b3658c091723e54c460f06e3b6af9e4602e0a233a10f397caa4"
+            "hash": "sha256:e2882f165ee2392376f6a136718606607c5579406edff46176f2c0be034ad6cb"
         }
     }
 }


### PR DESCRIPTION
This PR introduces a new `hooky show` command to the `hooky` CLI, allowing users to view which hooks are currently being managed by GetHooky, as well as inspect their contents.

Closes #10.

## Summary
- Added `cmd/show.go` with CLI logic for `hooky show`
- `hooky show` lists all hooks in the .hooky directory
- `hooky show <hook>` prints the contents of a specific hook
- Updated core logic to support reading hook files
- Added unit tests for show functionality in `core_test.go`

## Examples
```bash
hooky show
Current hooks:
- pre-commit
```
```bash
hooky show pre-commit
go test ./... -v
```
